### PR TITLE
corrected problem for case when file is smaller than chunk size

### DIFF
--- a/calculate_multipart_etag.py
+++ b/calculate_multipart_etag.py
@@ -46,14 +46,15 @@ def calculate_multipart_etag(source_path, chunk_size, expected=None):
                 break
             md5s.append(hashlib.md5(data))
 
-    digests = b"".join(m.digest() for m in md5s)
+   
     if len(md5s) > 1:
+	digests = b"".join(m.digest() for m in md5s)
         new_md5 = hashlib.md5(digests)
         new_etag = '"%s-%s"' % (new_md5.hexdigest(),len(md5s))
     elif len(md5s) == 1: # file smaller than chunk size
-        new_etag = md5s[0].hexdigest()
+        new_etag = '"%s"' % md5s[0].hexdigest()
     else: # empty file
-        new_etag = ''
+        new_etag = '""'
 
     if expected:
         if not expected==new_etag:

--- a/calculate_multipart_etag.py
+++ b/calculate_multipart_etag.py
@@ -47,9 +47,14 @@ def calculate_multipart_etag(source_path, chunk_size, expected=None):
             md5s.append(hashlib.md5(data))
 
     digests = b"".join(m.digest() for m in md5s)
+    if len(md5s) > 1:
+        new_md5 = hashlib.md5(digests)
+        new_etag = '"%s-%s"' % (new_md5.hexdigest(),len(md5s))
+    elif len(md5s) == 1: # file smaller than chunk size
+        new_etag = md5s[0].hexdigest()
+    else: # empty file
+        new_etag = ''
 
-    new_md5 = hashlib.md5(digests)
-    new_etag = '"%s-%s"' % (new_md5.hexdigest(),len(md5s))
     if expected:
         if not expected==new_etag:
             raise ValueError('new etag %s does not match expected %s' % (new_etag,expected))


### PR DESCRIPTION
AWS S3 ETags have a different format when the file was uploaded in one part. this occurs when the file is smaller than chunk size.